### PR TITLE
Create skip and continue component

### DIFF
--- a/src/Components/Onboarding/Onboarding_Skip_Continue_Buttons/Onboarding_Skip_Continue_Buttons.js
+++ b/src/Components/Onboarding/Onboarding_Skip_Continue_Buttons/Onboarding_Skip_Continue_Buttons.js
@@ -1,0 +1,27 @@
+import React, { useState } from "react";
+import OnboardingButton from "../Onboarding_Button/Onboarding_Button";
+import Onboarding_Alert_Modal from "../Onboarding_Alert_Modal/Onboarding_Alert_Modal";
+
+// To use the Skip/Continue component: 
+//   1) pass the state of the Continue Button (true or false)
+//   2) pass the id of the form 
+export default function Onboarding_Skip_Continue_Btns(props) {
+  
+
+  return (
+    <div className="w-[100%]">
+      <OnboardingButton
+        type="submit"
+        form={props.formID}
+        btnText='Continue'
+        disabled={props.disabledState}
+      />
+      <button
+        onClick={onSkip}
+        className='text-[#0A70E8] underline my-[24px]'
+      >
+        Skip
+      </button>
+    </div>
+  )
+}

--- a/src/Components/Onboarding/Onboarding_Skip_Continue_Buttons/Onboarding_Skip_Continue_Buttons.js
+++ b/src/Components/Onboarding/Onboarding_Skip_Continue_Buttons/Onboarding_Skip_Continue_Buttons.js
@@ -1,27 +1,56 @@
 import React, { useState } from "react";
+import { useNavigate } from 'react-router-dom';
 import OnboardingButton from "../Onboarding_Button/Onboarding_Button";
-import Onboarding_Alert_Modal from "../Onboarding_Alert_Modal/Onboarding_Alert_Modal";
+import OnboardingAlertModal from "../Onboarding_Alert_Modal/Onboarding_Alert_Modal";
+import warning from "../../../Assets/Icons/Onboarding_Icons/warning.svg";
+import exit from "../../../Assets/Icons/Onboarding_Icons/exit.svg";
 
-// To use the Skip/Continue component: 
-//   1) pass the state of the Continue Button (true or false)
-//   2) pass the id of the form 
+// To use the Skip/Continue component, pass the following props: 
+//   1) pass the filepath to navigate to (skipToPage)
+//   2) pass the id of the form (formID)
+//   3) pass the button text of the Continue Btn (btnText)
+//   4) pass the state of the Continue Button (disabledState will be true or false)
+//   5) pass Alert Message (message)
+
+// Issues: Modal doesn't appear at top of the page
+
 export default function Onboarding_Skip_Continue_Btns(props) {
-  
+  const navigate = useNavigate();
+  const [showAlert, setShowAlert] = useState(false);
+
+  const handleSkip = () => {
+    setShowAlert(false);
+    navigate(props.skipToPage)
+  }
 
   return (
-    <div className="w-[100%]">
+    <div className="w-[100%] flex flex-col justify-center items-center">
       <OnboardingButton
         type="submit"
         form={props.formID}
-        btnText='Continue'
+        btnText={props.btnText}
         disabled={props.disabledState}
+        className="w-[100%]"
       />
       <button
-        onClick={onSkip}
+        onClick={() => setShowAlert(true)}
         className='text-[#0A70E8] underline my-[24px]'
       >
         Skip
       </button>
+      <OnboardingAlertModal 
+        isVisible={showAlert ? 'visible' : 'hidden'}
+        message={props.message}
+        border="border-[#D82D07]"
+        background="bg-[#FFDDDF]"
+        iconLeft={warning}
+        iconLeftAlt='warning'
+        iconRight={exit}
+        iconRightAlt='exit button'
+        skipBtnVisible={true}
+        skipBtnOnClick={handleSkip}
+        exitBtnOnClick={() => setShowAlert(false)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Created the skip and continue component. Navigation for the skip button works, will just need to pass the filepath as props. 

Issue: I think the Alert Modal Component might need to have some kind of fixed positioning so it will always appear at the top at the page. 

Screenshots (tested the component on page Onboarding_1 page): 

![Screen Shot 2023-12-04 at 12 14 16 AM](https://github.com/cr8t-studio/syne-mvp/assets/78467590/a7f31713-b7e7-478c-bdd5-f1af1ba18710)

Modal appearing overtop the buttons at the bottom of the page: 
![Screen Shot 2023-12-04 at 12 13 57 AM](https://github.com/cr8t-studio/syne-mvp/assets/78467590/6ebab441-b71b-4f69-9386-a9a24a6a93da)
