### PR TITLE
fix resizing issue for large checkbox container

### DIFF
--- a/src/Components/Onboarding/Onboarding_Large_Checkbox/Onboarding_large_checkbox.js
+++ b/src/Components/Onboarding/Onboarding_Large_Checkbox/Onboarding_large_checkbox.js
@@ -7,7 +7,7 @@ export default function Onboarding_Checkbox(props) {
   const [hover, setHover] = useState(false);
 
   return (
-    <div className=' flex flex-row justify-center items-center'>
+    <div className=' flex flex-row justify-center items-center w-full'>
       <input
         type='checkbox'
         id={props.id}
@@ -18,7 +18,7 @@ export default function Onboarding_Checkbox(props) {
       />
       <label
         htmlFor={props.for}
-        className={`option-wrapper flex items-center w-fit h-auto p-[14px] font-Poppins font-medium text-[16+8px] text-center leading-[28px] text-[#212529] select-none cursor-pointer rounded-[8px]  border  transition-colors duration-200 ease-in-out ${
+        className={`option-wrapper flex items-center w-full h-auto p-[14px] font-Poppins font-medium text-[16+8px] text-center leading-[28px] text-[#212529] select-none cursor-pointer rounded-[8px]  border  transition-colors duration-200 ease-in-out ${
           hover ? " border-[#556AEB] " : " border-[#6C757D] "
         } ${selected ? " bg-[#EBEFFF] " : " bg-white "}`}
         onMouseOver={() => {
@@ -31,10 +31,10 @@ export default function Onboarding_Checkbox(props) {
           setSelected(!selected);
         }}
       >
-        <div className='flex flex-row items-center justify-between w-[392px]'>
-          <div className='flex items-center'>
+        <div className='flex flex-row items-center w-full'>
+          <div className='flex items-center w-full'>
             <div
-              className={`icon-wrapper p-3 rounded-md transition-colors duration-200 ease-in-out  ${
+              className={`icon-wrapper p-3 rounded-md transition-colors duration-200 ease-in-out ${
                 selected || hover ? " bg-[#B9C4FF] " : "bg-[#E9ECEF]"
               }   
               


### PR DESCRIPTION
Solution: remove fixed width on one of the divs, before it was fixed to a width of 392px so that's why it wasn't resizing. Then added w-full so it could resize to the parent container. 

Note for later: Will need to add some kind of overall page padding on the sides so the content doesn't touch the sides of the screen

Screenshots of a screen with a width of 392px: 
Before: 
<img width="430" alt="Screen Shot 2023-12-05 at 10 47 58 PM" src="https://github.com/cr8t-studio/syne-mvp/assets/78467590/7b750727-050a-445e-b6f3-2ea8d5b3a52e">

After: 
<img width="422" alt="Screen Shot 2023-12-05 at 10 45 23 PM" src="https://github.com/cr8t-studio/syne-mvp/assets/78467590/6752284d-8a69-4ea2-a2a7-6c68c6c72a33">
