### PR TITLE
Formatting Onboarding_header/nav

### DIFF
--- a/src/Assets/Icons/Onboarding_Icons/back.svg
+++ b/src/Assets/Icons/Onboarding_Icons/back.svg
@@ -1,1 +1,3 @@
-<svg class="hover:fill-blue-600" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="m313-440 224 224-57 56-320-320 320-320 57 56-224 224h487v80H313Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z" fill="black"/>
+</svg>

--- a/src/Components/Onboarding/Onboarding_Skip_Continue_Buttons/Onboarding_Skip_Continue_Buttons.js
+++ b/src/Components/Onboarding/Onboarding_Skip_Continue_Buttons/Onboarding_Skip_Continue_Buttons.js
@@ -37,7 +37,7 @@ export default function Onboarding_Skip_Continue_Btns(props) {
           e.preventDefault();
           setShowAlert(true);
         }}
-        className='text-[#0A70E8] underline my-[24px]'
+        className='text-[#0A70E8] hover:underline my-[24px]'
       >
         {props.skipMessage ? props.skipMessage : "Skip"}
       </button>

--- a/src/Components/Onboarding/Onboarding_nav/Onboarding_nav.js
+++ b/src/Components/Onboarding/Onboarding_nav/Onboarding_nav.js
@@ -113,16 +113,18 @@ export default function Onboarding_Nav(props) {
                  
       </div>
     </button>
-    <Onboarding_Action_Modal
-      isVisible={showAlert ? "visible" : "hidden"}
-      modalPosition=''
-      title="Close your workspace setup?"
-      message="You will skip all the set up and be taken to workspace dashboard."
-      topBtnText="Continue setup"
-      topBtnOnClick={() => setShowAlert(false)}
-      bottomBtnText="Skip all setup"
-      bottomBtnOnClick={handleSkip}
-    />
+      {showAlert && (<div className='fixed inset-0 flex items-center justify-center'>
+        <Onboarding_Action_Modal
+        isVisible={showAlert ? "visible" : "hidden"}
+        title="Close your workspace setup?"
+        message="You will skip all the set up and be taken to workspace dashboard."
+        topBtnText="Continue setup"
+        topBtnOnClick={() => setShowAlert(false)}
+        bottomBtnText="Skip all setup"
+        bottomBtnOnClick={handleSkip}
+        />
+      </div>
+      )}
     </div>
     )}
     </div>

--- a/src/Components/Onboarding/Onboarding_nav/Onboarding_nav.js
+++ b/src/Components/Onboarding/Onboarding_nav/Onboarding_nav.js
@@ -4,6 +4,7 @@ import back from "../../../Assets/Icons/Onboarding_Icons/back.svg"
 import back_selected from "../../../Assets/Icons/Onboarding_Icons/back_selected.svg"
 import exit from "../../../Assets/Icons/Onboarding_Icons/exit.svg"
 import Onboarding_Action_Modal from "../Onboarding_Action_Modal/Onboarding_Action_Modal"
+import syne_logo from "../../../Assets/Icons/syne-logo.svg";
 
 export default function Onboarding_Nav(props) {
   const currentLocation = useLocation();
@@ -42,11 +43,25 @@ export default function Onboarding_Nav(props) {
     }
   };
 
+  // Only show nav bar if we can go to previous page
+  const renderNavBar = currentLocation.pathname !== '/onboarding_1';
+
   return (
     //* Back and Exit buttons
-<div class="flex p-4 md:p-16 justify-between items-center self-stretch">
+    <div className=' w-[100%] self-stretch'>
+      <div className='header-inner-wrapper w-[1440px] h-[72px] mx-[24px] pt-[16px] pb-[16px] flex justify-start items-center pr-'>
+        <img
+          className='w-[30px] h-[30px] mr-[14px]'
+          src={syne_logo}
+          alt='Syne Logo'
+        />
+        <p className='font-Poppins text-[20px] font-normal leading-[30px] tracking-[-0.266px]'>
+          Syne
+        </p>
+      </div>
+      {renderNavBar && (
+        <div className="flex p-16 px-74 h-[64px] pt-[16px] pb-[136px] justify-between items-center self-stretch">
       <Link
-        //^  Fonts wont update
         className='flex'
         to={traverseBack(currentLocation.pathname)}
         onClick={() => {
@@ -60,11 +75,10 @@ export default function Onboarding_Nav(props) {
           );
         }}
       >
-        <div class="flex items-center hover:text-[#556AEB]"
+        <div class="flex items-center gap-[2px] hover:text-[#556AEB]"
           onMouseEnter={() => setIsBackHovered(true)}
           onMouseLeave={() => setIsBackHovered(false)} >
           <img
-            class='mr-2'
             src={isBackHovered ? back_selected : back}
             alt='back'
           />  
@@ -91,7 +105,6 @@ export default function Onboarding_Nav(props) {
           height: '32px', 
         }}
       >
- 
       <img
           className=''
           src={exit}
@@ -110,6 +123,8 @@ export default function Onboarding_Nav(props) {
       bottomBtnText="Skip all setup"
       bottomBtnOnClick={handleSkip}
     />
+    </div>
+    )}
     </div>
   );
 }

--- a/src/Pages/Onboarding/Onboarding_1.js
+++ b/src/Pages/Onboarding/Onboarding_1.js
@@ -1,9 +1,9 @@
 /* eslint-disable react/jsx-pascal-case */
 import React from "react";
-import Onboarding_header from "../../Components/Onboarding/Onboarding_header/Onboarding_header";
 import Onboarding_Checkbox_Large from "../../Components/Onboarding/Onboarding_Large_Checkbox/Onboarding_large_checkbox";
 import Onboarding_Skip_Continue_Btns from "../../Components/Onboarding/Onboarding_Skip_Continue_Buttons/Onboarding_Skip_Continue_Buttons";
 import Onboarding_progress_bar from "../../Components/Onboarding/Onboarding_progress_bar/Onboarding_progress_bar";
+import Onboarding_nav from "../../Components/Onboarding/Onboarding_nav/Onboarding_nav";
 
 import Person from "../../Assets/Icons/Onboarding_Icons/person.svg";
 import Team from "../../Assets/Icons/Onboarding_Icons/team.svg";
@@ -39,9 +39,9 @@ export default function Onboarding_1() {
   ];
 
   return (
+    
     <div className='flex flex-col justify-center items-center'>
-      <Onboarding_header />
-
+      <Onboarding_nav/>
       <div className='title-and-button-wrapper max-w-fit h-auto mt-[50px] flex flex-col justify-center items-center'>
         <div className='text-wrapper relative flex flex-col items-center w-[100%] h-auto gap-[16px] '>
           {/* //TODO: update margin once back and exit Btn's are built */}

--- a/src/Pages/Onboarding/Onboarding_2.js
+++ b/src/Pages/Onboarding/Onboarding_2.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-pascal-case */
 import React from "react";
-import Onboarding_header from "../../Components/Onboarding/Onboarding_header/Onboarding_header";
 import Onboarding_progress_bar from "../../Components/Onboarding/Onboarding_progress_bar/Onboarding_progress_bar";
 import Onboarding_nav from "../../Components/Onboarding/Onboarding_nav/Onboarding_nav";
 import Onboarding_Checkbox from "../../Components/Onboarding/Onboarding_Checkbox/Onboarding_Checkbox";
@@ -9,8 +8,6 @@ import Onboarding_Skip_Continue_Btns from "../../Components/Onboarding/Onboardin
 export default function Onboarding_2() {
   return (
     <div className='flex flex-col justify-center items-center'>
-      <Onboarding_header />
-
       {/* Change the active prop to page2, page3 etc to change the color of the corresponding bar */}
       <Onboarding_nav />
 

--- a/src/Pages/Onboarding/Onboarding_3.js
+++ b/src/Pages/Onboarding/Onboarding_3.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-pascal-case */
 import React from "react";
-import Onboarding_header from "../../Components/Onboarding/Onboarding_header/Onboarding_header";
 import Onboarding_progress_bar from "../../Components/Onboarding/Onboarding_progress_bar/Onboarding_progress_bar";
 import Onboarding_nav from "../../Components/Onboarding/Onboarding_nav/Onboarding_nav";
 import Onboarding_Checkbox from "../../Components/Onboarding/Onboarding_Checkbox/Onboarding_Checkbox";
@@ -9,11 +8,9 @@ import Onboarding_Skip_Continue_Btns from "../../Components/Onboarding/Onboardin
 export default function Onboarding_3() {
   return (
     <div className='flex flex-col justify-center items-center'>
-      <Onboarding_header />
       <Onboarding_nav />
 
       {/* Change the active prop to page2, page3 etc to change the color of the corresponding bar */}
-
       <div className='title-and-button-wrapper max-w-[714px] h-auto mt-[20px] flex flex-col justify-center items-center'>
         <div className='text-wrapper h-auto flex flex-col gap-[24px]'>
           <h1 className='w-[100%] min-h-[54px] font-Poppins text-[40px] font-semibold text-[#212529] text-center leading-[54px]'>

--- a/src/Pages/Onboarding/Onboarding_4.js
+++ b/src/Pages/Onboarding/Onboarding_4.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-pascal-case */
 import React, { useState } from "react";
-import Onboarding_header from "../../Components/Onboarding/Onboarding_header/Onboarding_header";
 import Onboarding_progress_bar from "../../Components/Onboarding/Onboarding_progress_bar/Onboarding_progress_bar";
 
 import Onboarding_Nav from "../../Components/Onboarding/Onboarding_nav/Onboarding_nav";
@@ -68,7 +67,6 @@ export default function Onboarding_4() {
 
   return (
     <div className='relative flex flex-col justify-start items-center w-screen h-screen'>
-      <Onboarding_header />
       <Onboarding_Nav />
       <div className='title-and-form-wrapper max-w-[730px] mt-[20px] mx-[20px] h-auto flex flex-col justify-center items-center'>
         <div className='text-wrapper max-w-[730px] h-auto flex flex-col justify-start items-center'>

--- a/src/Pages/Onboarding/Onboarding_5.js
+++ b/src/Pages/Onboarding/Onboarding_5.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-pascal-case */
 import React, { useState } from "react";
-import Onboarding_header from "../../Components/Onboarding/Onboarding_header/Onboarding_header";
 import Onboarding_progress_bar from "../../Components/Onboarding/Onboarding_progress_bar/Onboarding_progress_bar";
 import Onboarding_nav from "../../Components/Onboarding/Onboarding_nav/Onboarding_nav";
 import shareLink from "../../Assets/Icons/Onboarding_Icons/link.svg";
@@ -21,7 +20,6 @@ export default function Onboarding_5() {
   }
   return (
     <div className='flex flex-col justify-center items-center'>
-      <Onboarding_header />
       <Onboarding_nav />
       <div className='title-and-form-wrapper max-w-[730px] mx-[20px] h-auto flex flex-col justify-center items-center'>
         <div className='text-wrapper max-w-[730px] h-auto mb-[48px] flex flex-col justify-start items-center'>

--- a/src/Pages/Onboarding/Onboarding_6.js
+++ b/src/Pages/Onboarding/Onboarding_6.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-pascal-case */
 import React from "react";
-import Onboarding_header from "../../Components/Onboarding/Onboarding_header/Onboarding_header";
 import Onboarding_progress_bar from "../../Components/Onboarding/Onboarding_progress_bar/Onboarding_progress_bar";
 import Onboarding_nav from "../../Components/Onboarding/Onboarding_nav/Onboarding_nav";
 import Onboarding_Dropdown from "../../Components/Onboarding/Onboarding_Dropdown/Onboarding_dropdown";
@@ -19,7 +18,7 @@ export default function Onboarding_6() {
   }
   return (
     <div className='flex flex-col justify-center items-center'>
-      <Onboarding_header />
+      <Onboarding_nav/>
 
       {/* Change the active prop to page2, page3 etc to change the color of the corresponding bar */}
       <Onboarding_progress_bar active='page6' />


### PR DESCRIPTION
Placed Onboarding_header into Onboarding_nav component in order to achieve correct padding.
Fixed formatting issue that was causing alert to overlap with navbar:
![Screenshot 2023-12-14 at 8 39 28 PM](https://github.com/cr8t-studio/syne-mvp/assets/59468977/4b01c8ac-7fa4-4f1f-b223-5f6f0b16a158)

Screenshot of previous formatting:
![Screenshot 2023-12-14 at 8 43 59 PM](https://github.com/cr8t-studio/syne-mvp/assets/59468977/43bf3a2a-67b1-4b2d-8433-61ba5056e3c5)

Small changes include:
Changed Skip button to underline on hover instead of default
Centered "Close Workspace" modal